### PR TITLE
read non-system workitem fields as "other fields" in a map

### DIFF
--- a/azd/src/main/java/org/azd/workitemtracking/types/WorkItemFields.java
+++ b/azd/src/main/java/org/azd/workitemtracking/types/WorkItemFields.java
@@ -1,8 +1,13 @@
 package org.azd.workitemtracking.types;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.azd.common.Author;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WorkItemFields {
@@ -84,6 +89,25 @@ public class WorkItemFields {
     private String acceptanceCriteria;
     @JsonProperty("System.Tags")
     private String systemTags;
+
+    // for non-system (custom) fields
+    Map<String, Object> otherFields = new HashMap<>();
+
+    // Capture all other fields that Jackson do not match other members
+    @JsonAnyGetter
+    public Map<String, Object> getOtherFields() {
+        return otherFields;
+    }
+
+    public void setOtherFields(Map<String, Object> otherFieldsParam) {
+        otherFields = otherFieldsParam;
+    }
+
+    @JsonAnySetter
+    public void setOtherField(String name, Object value) {
+        // TODO the value could be mappable to a reference, like a user/author
+        otherFields.put(name, value);
+    }
 
     public int getSystemAreaId() {
         return systemAreaId;


### PR DESCRIPTION
## Description
import non standard workitem fields as a map "otherFields"

note: some fields inWorkItemFields seem non-standard and should be removed
    @JsonProperty("WEF_98038F99D72A41E6AC7951F5027AA23A_System.ExtensionMarker")
    private boolean systemExtensionMarker;
    @JsonProperty("WEF_98038F99D72A41E6AC7951F5027AA23A_Kanban.Column")
    private String kanbanColumn;
    @JsonProperty("WEF_98038F99D72A41E6AC7951F5027AA23A_Kanban.Column.Done")
    private boolean kanbanColumnDone;

## PR Checklist

- [x] Added help
- [x] Added unit test/s
- [x] Updated Change log