### PR TITLE
Expanded the WorkItemTrackingDetails interface with two updateWorkItem methods and added hyperlinks support.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,26 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,4 +23,4 @@ jobs:
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file src/pom.xml
+      run: mvn -B package --file azd/pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,4 +23,4 @@ jobs:
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file src/pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,4 +23,4 @@ jobs:
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file azd/pom.xml
+      run: mvn -B package --file azd/pom.xml -DskipTests

--- a/azd/src/main/java/org/azd/interfaces/WorkItemTrackingDetails.java
+++ b/azd/src/main/java/org/azd/interfaces/WorkItemTrackingDetails.java
@@ -1,49 +1,243 @@
 package org.azd.interfaces;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.azd.enums.WorkItemErrorPolicy;
 import org.azd.enums.WorkItemExpand;
 import org.azd.enums.WorkItemOperation;
 import org.azd.exceptions.AzDException;
 import org.azd.exceptions.ConnectionException;
-import org.azd.workitemtracking.types.*;
-
-import java.util.HashMap;
+import org.azd.workitemtracking.types.WorkItem;
+import org.azd.workitemtracking.types.WorkItemDelete;
+import org.azd.workitemtracking.types.WorkItemDeleteReference;
+import org.azd.workitemtracking.types.WorkItemDeleteReferences;
+import org.azd.workitemtracking.types.WorkItemDeleteShallowReferences;
+import org.azd.workitemtracking.types.WorkItemList;
+import org.azd.workitemtracking.types.WorkItemQueryResult;
+import org.azd.workitemtracking.types.WorkItemType;
+import org.azd.workitemtracking.types.WorkItemTypes;
 
 public interface WorkItemTrackingDetails {
-    WorkItem createWorkItem(String workItemType, WorkItemOperation operation, String title) throws ConnectionException, AzDException;
-    WorkItem createWorkItem(String workItemType,
-                            WorkItemOperation operation, String title, String description,
-                            String[] tags) throws ConnectionException, AzDException;
-    WorkItem createWorkItem(String workItemType, String title, String description, HashMap<String, Object> additionalFields)
-            throws ConnectionException, AzDException;
-    WorkItemDelete deleteWorkItem(int id) throws ConnectionException, AzDException;
-    void deleteWorkItem(int id, boolean destroy) throws ConnectionException, AzDException;
-    WorkItem getWorkItem(int id) throws ConnectionException, AzDException;
-    WorkItem getWorkItem(int id, WorkItemExpand expand) throws ConnectionException, AzDException;
-    WorkItem getWorkItem(int id, WorkItemExpand expand, String asOf) throws ConnectionException, AzDException;
-    WorkItem getWorkItem(int id, WorkItemExpand expand, String[] fields) throws ConnectionException, AzDException;
-    WorkItem getWorkItem(int id, WorkItemExpand expand, String[] fields, String asOf) throws ConnectionException, AzDException;
-    WorkItemList getWorkItems(int[] ids) throws ConnectionException, AzDException;
-    WorkItemList getWorkItems(int[] ids, WorkItemExpand expand) throws ConnectionException, AzDException;
-    WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String asOf) throws ConnectionException, AzDException;
-    WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String[] fields) throws ConnectionException, AzDException;
-    WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String[] fields,
-                              String asOf, WorkItemErrorPolicy errorPolicy) throws ConnectionException, AzDException;
-    WorkItemList getWorkItemRevisions(int workItemId) throws ConnectionException, AzDException;
-    WorkItemList getWorkItemRevisions(int workItemId, WorkItemExpand expand) throws ConnectionException, AzDException;
-    WorkItemList getWorkItemRevisions(int workItemId, WorkItemExpand expand, int top, int skip) throws ConnectionException, AzDException;
-    WorkItem getWorkItemRevision(int workItemId, int revisionNumber) throws ConnectionException, AzDException;
-    WorkItem getWorkItemRevision(int workItemId, int revisionNumber, WorkItemExpand expand) throws ConnectionException, AzDException;
-    WorkItemQueryResult queryByWiql(String team, String query) throws ConnectionException, AzDException;
-    WorkItemQueryResult queryByWiql(String team, String query, int top, boolean timePrecision) throws ConnectionException, AzDException;
-    void removeWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException;
-    WorkItemDeleteReference getWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException;
-    WorkItemDeleteShallowReferences getDeletedWorkItemsFromRecycleBin() throws ConnectionException, AzDException;
-    WorkItemDeleteReferences getDeletedWorkItemsFromRecycleBin(int[] ids) throws ConnectionException, AzDException;
-    WorkItemDeleteReference restoreWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException;
-    WorkItem updateWorkItem(int workItemId, HashMap<String, Object> fieldsToUpdate) throws ConnectionException, AzDException;
-    WorkItem updateWorkItem(int workItemId, WorkItemExpand expand, boolean bypassRules, boolean suppressNotifications,
-                            boolean validateOnly, HashMap<String, Object> fieldsToUpdate) throws ConnectionException, AzDException;
-    WorkItemTypes getWorkItemTypes() throws ConnectionException, AzDException;
-    WorkItemType getWorkItemType(String workItemTypeName) throws ConnectionException, AzDException;
+
+	WorkItem createWorkItem(String workItemType, WorkItemOperation operation, String title)
+			throws ConnectionException, AzDException;
+
+	WorkItem createWorkItem(String workItemType, WorkItemOperation operation, String title, String description,
+			String[] tags) throws ConnectionException, AzDException;
+
+	WorkItem createWorkItem(String workItemType, String title, String description,
+			HashMap<String, Object> additionalFields) throws ConnectionException, AzDException;
+
+	WorkItemDelete deleteWorkItem(int id) throws ConnectionException, AzDException;
+
+	void deleteWorkItem(int id, boolean destroy) throws ConnectionException, AzDException;
+
+	WorkItem getWorkItem(int id) throws ConnectionException, AzDException;
+
+	WorkItem getWorkItem(int id, WorkItemExpand expand) throws ConnectionException, AzDException;
+
+	WorkItem getWorkItem(int id, WorkItemExpand expand, String asOf) throws ConnectionException, AzDException;
+
+	WorkItem getWorkItem(int id, WorkItemExpand expand, String[] fields) throws ConnectionException, AzDException;
+
+	WorkItem getWorkItem(int id, WorkItemExpand expand, String[] fields, String asOf)
+			throws ConnectionException, AzDException;
+
+	WorkItemList getWorkItems(int[] ids) throws ConnectionException, AzDException;
+
+	WorkItemList getWorkItems(int[] ids, WorkItemExpand expand) throws ConnectionException, AzDException;
+
+	WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String asOf) throws ConnectionException, AzDException;
+
+	WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String[] fields)
+			throws ConnectionException, AzDException;
+
+	WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String[] fields, String asOf,
+			WorkItemErrorPolicy errorPolicy) throws ConnectionException, AzDException;
+
+	WorkItemList getWorkItemRevisions(int workItemId) throws ConnectionException, AzDException;
+
+	WorkItemList getWorkItemRevisions(int workItemId, WorkItemExpand expand) throws ConnectionException, AzDException;
+
+	WorkItemList getWorkItemRevisions(int workItemId, WorkItemExpand expand, int top, int skip)
+			throws ConnectionException, AzDException;
+
+	WorkItem getWorkItemRevision(int workItemId, int revisionNumber) throws ConnectionException, AzDException;
+
+	WorkItem getWorkItemRevision(int workItemId, int revisionNumber, WorkItemExpand expand)
+			throws ConnectionException, AzDException;
+
+	WorkItemQueryResult queryByWiql(String team, String query) throws ConnectionException, AzDException;
+
+	WorkItemQueryResult queryByWiql(String team, String query, int top, boolean timePrecision)
+			throws ConnectionException, AzDException;
+
+	void removeWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException;
+
+	WorkItemDeleteReference getWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException;
+
+	WorkItemDeleteShallowReferences getDeletedWorkItemsFromRecycleBin() throws ConnectionException, AzDException;
+
+	WorkItemDeleteReferences getDeletedWorkItemsFromRecycleBin(int[] ids) throws ConnectionException, AzDException;
+
+	WorkItemDeleteReference restoreWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException;
+
+	/***
+	 * Update a single work item with the internal field names. The operation
+	 * type that will be used is {@link WorkItemOperation#ADD}.
+	 *
+	 * @param workItemId
+	 *            The id of the work item to update
+	 * @param fieldsToUpdate
+	 *            HashMap of internal field names to update. E.g., System.Title,
+	 *            System.Description etc and it's associated values.
+	 *
+	 * @return The updated {@link WorkItem}.
+	 *
+	 * @throws ConnectionException
+	 *             If the default parameters (organization name, project name
+	 *             and personal access token) are wrong or not set.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments.
+	 */
+	WorkItem updateWorkItem(int workItemId, HashMap<String, Object> fieldsToUpdate)
+			throws ConnectionException, AzDException;
+
+	/***
+	 * Update a single work item with the internal field names.
+	 *
+	 * @param workItemId
+	 *            The id of the work item to update
+	 * @param fieldsToUpdate
+	 *            HashMap of internal field names to update. E.g., System.Title,
+	 *            System.Description etc and it's associated values.
+	 * @param operation
+	 *            The {@link WorkItemOperation}.
+	 *
+	 * @return The updated {@link WorkItem}.
+	 *
+	 * @throws ConnectionException
+	 *             If the default parameters (organization name, project name
+	 *             and personal access token) are wrong or not set.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments.
+	 */
+	WorkItem updateWorkItem(int workItemId, HashMap<String, Object> fieldsToUpdate, WorkItemOperation operation)
+			throws ConnectionException, AzDException;
+
+	/***
+	 * Update a single work item with the internal field names. The operation
+	 * type that will be used is {@link WorkItemOperation#ADD}.
+	 *
+	 * @param workItemId
+	 *            The id of the work item to update
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @param bypassRules
+	 *            Do not enforce the work item type rules on this update
+	 * @param suppressNotifications
+	 *            Do not fire any notifications for this change
+	 * @param validateOnly
+	 *            Indicate if you only want to validate the changes without
+	 *            saving the work item
+	 * @param fieldsToUpdate
+	 *            HashMap of internal field names to update. E.g., System.Title,
+	 *            System.Description etc and it's associated values.
+	 *
+	 * @return WorkItemDeleteReference {@link WorkItemDeleteReference}
+	 *
+	 * @throws ConnectionException
+	 *             If the default parameters (organization name, project name
+	 *             and personal access token) are wrong or not set.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments.
+	 */
+	WorkItem updateWorkItem(int workItemId, WorkItemExpand expand, boolean bypassRules, boolean suppressNotifications,
+			boolean validateOnly, HashMap<String, Object> fieldsToUpdate) throws ConnectionException, AzDException;
+
+	/***
+	 * Update a single work item with the internal field names.
+	 *
+	 * @param workItemId
+	 *            The id of the work item to update
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @param bypassRules
+	 *            Do not enforce the work item type rules on this update
+	 * @param suppressNotifications
+	 *            Do not fire any notifications for this change
+	 * @param validateOnly
+	 *            Indicate if you only want to validate the changes without
+	 *            saving the work item
+	 * @param fieldsToUpdate
+	 *            HashMap of internal field names to update. E.g., System.Title,
+	 *            System.Description etc and it's associated values.
+	 * @param operation
+	 *            The {@link WorkItemOperation}.
+	 *
+	 * @return WorkItemDeleteReference {@link WorkItemDeleteReference}
+	 *
+	 * @throws ConnectionException
+	 *             If the default parameters (organization name, project name
+	 *             and personal access token) are wrong or not set.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments.
+	 */
+	WorkItem updateWorkItem(int workItemId, WorkItemExpand expand, boolean bypassRules, boolean suppressNotifications,
+			boolean validateOnly, HashMap<String, Object> fieldsToUpdate, WorkItemOperation operation)
+			throws ConnectionException, AzDException;
+
+	/**
+	 * Create hyperlinks for the given work item.
+	 *
+	 * @param workItemId
+	 *            The work item's ID.
+	 * @param hyperlinksMap
+	 *            A {@link Map} that each entry represents a hyperlink. The key
+	 *            is the hyperlink URL and the value is its comment. If a
+	 *            comment is not desired then the value can either be null (if
+	 *            its supported by the map) or an empty string.
+	 *
+	 * @return The updated {@link WorkItem}.
+	 *
+	 * @throws ConnectionException
+	 *             If the default parameters (organization name, project name
+	 *             and personal access token) are wrong or not set.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments.
+	 */
+	WorkItem addHyperLinks(int workItemId, Map<String, String> hyperlinksMap) throws ConnectionException, AzDException;
+
+	/**
+	 * Remove hyperlinks for the given work item.
+	 *
+	 * <p>
+	 * <b>Note:</b> All hyperlinks must exist in order to be removed. Even if
+	 * one doesn't then an {@link AzDException} is thrown.
+	 * </p>
+	 *
+	 * @param workItemId
+	 *            The work item's ID.
+	 * @param urls
+	 *            A {@link List} with the URL of the hyperlinks.
+	 *
+	 * @return The updated {@link WorkItem}.
+	 *
+	 * @throws ConnectionException
+	 *             If the default parameters (organization name, project name
+	 *             and personal access token) are wrong or not set.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments.
+	 */
+	WorkItem removeHyperLinks(int workItemId, List<String> urls) throws ConnectionException, AzDException;
+
+	WorkItemTypes getWorkItemTypes() throws ConnectionException, AzDException;
+
+	WorkItemType getWorkItemType(String workItemTypeName) throws ConnectionException, AzDException;
 }

--- a/azd/src/main/java/org/azd/workitemtracking/WorkItemTrackingApi.java
+++ b/azd/src/main/java/org/azd/workitemtracking/WorkItemTrackingApi.java
@@ -1,5 +1,16 @@
 package org.azd.workitemtracking;
 
+import static org.azd.helpers.URLHelper.encodeSpace;
+import static org.azd.utils.Client.send;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import org.azd.common.ApiVersion;
 import org.azd.connection.Connection;
 import org.azd.enums.RequestMethod;
@@ -10,784 +21,1217 @@ import org.azd.exceptions.AzDException;
 import org.azd.exceptions.ConnectionException;
 import org.azd.helpers.JsonMapper;
 import org.azd.interfaces.WorkItemTrackingDetails;
-import org.azd.workitemtracking.types.*;
-
-import java.util.*;
-
-import static org.azd.helpers.URLHelper.encodeSpace;
-import static org.azd.utils.Client.send;
+import org.azd.workitemtracking.types.WorkItem;
+import org.azd.workitemtracking.types.WorkItemDelete;
+import org.azd.workitemtracking.types.WorkItemDeleteReference;
+import org.azd.workitemtracking.types.WorkItemDeleteReferences;
+import org.azd.workitemtracking.types.WorkItemDeleteShallowReferences;
+import org.azd.workitemtracking.types.WorkItemList;
+import org.azd.workitemtracking.types.WorkItemQueryResult;
+import org.azd.workitemtracking.types.WorkItemRelations;
+import org.azd.workitemtracking.types.WorkItemType;
+import org.azd.workitemtracking.types.WorkItemTypes;
 
 /***
  * WorkItem Tracking class to manage work items API
  */
 public class WorkItemTrackingApi implements WorkItemTrackingDetails {
-    /***
-     * Connection object
-     */
-    private final Connection CONNECTION;
-    private final JsonMapper MAPPER = new JsonMapper();
-    private final String AREA = "wit";
-    private final String WIT = "5264459e-e5e0-4bd8-b118-0985e68a4ec5";
-
-    /***
-     * Pass the connection object to work with WorkItem Tracking Api
-     * @param connection Connection object
-     */
-    public WorkItemTrackingApi(Connection connection) { this.CONNECTION = connection; }
-
-    /***
-     * Creates a single work item.
-     * @param workItemType The work item type of the work item to create. e.g., "user story", "bug", "task"
-     * @param operation The patch operation {@link WorkItemOperation}
-     * @param title The title for the work item
-     * @return {@link WorkItem}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItem createWorkItem(String workItemType,
-                                   WorkItemOperation operation,
-                                   String title) throws ConnectionException, AzDException {
-        var req = new HashMap<String, Object>(){{
-            put("op", operation.toString().toLowerCase());
-            put("path", "/fields/System.Title");
-            put("from", null);
-            put("value", title);
-        }};
-
-        String r = send(RequestMethod.POST, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems",  null, "$"+ encodeSpace(workItemType), ApiVersion.WORK_ITEM_TRACKING,
-                null, null, List.of(req), null);
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Creates a single work item.
-     * @param workItemType The work item type of the work item to create. e.g., "user story", "bug", "task"
-     * @param operation The patch operation {@link WorkItemOperation}
-     * @param title The title for the work item
-     * @param description Description for the work item
-     * @param tags Tags for the work item
-     * @return {@link WorkItem}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItem createWorkItem(String workItemType,
-                                   WorkItemOperation operation, String title,
-                                   String description, String[] tags) throws ConnectionException, AzDException {
-        var t = new HashMap<String, Object>(){{
-            put("op", operation.toString().toLowerCase());
-            put("path", "/fields/System.Title");
-            put("from", null);
-            put("value", title);
-        }};
-
-        var d = new HashMap<String, Object>(){{
-            put("op", operation.toString().toLowerCase());
-            put("path", "/fields/System.Description");
-            put("from", null);
-            put("value", description);
-        }};
-
-        var tt = new HashMap<String, Object>(){{
-            put("op", operation.toString().toLowerCase());
-            put("path", "/fields/System.Tags");
-            put("from", null);
-            put("value", String.join(",", tags));
-        }};
-
-        var req = new ArrayList<>();
-        req.add(t);
-        req.add(d);
-        req.add(tt);
-
-        String r = send(RequestMethod.POST, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems",  null, "$"+ encodeSpace(workItemType), ApiVersion.WORK_ITEM_TRACKING,
-                null, null, req, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Creates a single work item optionally with additional fields.
-     * @param workItemType The work item type of the work item to create. e.g., "user story", "bug", "task"
-     * @param title The title for the work item
-     * @param description Description for the work item
-     * @param additionalFields Provide the additional fields as a HashMap to create the work item.
-     * This requires the internal fields to be specified. E.g., System.Tags, System.AreaPath, System.State, System.Reason etc.,
-     * @return {@link WorkItem}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItem createWorkItem(String workItemType, String title, String description, HashMap<String, Object> additionalFields)
-            throws ConnectionException, AzDException {
-        var req = new ArrayList<>();
-
-        var t = new HashMap<String, Object>(){{
-            put("op", "add");
-            put("path", "/fields/System.Title");
-            put("from", null);
-            put("value", title);
-        }};
-
-        var d = new HashMap<String, Object>(){{
-            put("op", "add");
-            put("path", "/fields/System.Description");
-            put("from", null);
-            put("value", description);
-        }};
-
-        req.add(t);
-        req.add(d);
-
-        for (var key : additionalFields.keySet()) {
-            var i = new HashMap<String, Object>(){{
-                put("op", "add");
-                put("path", "/fields/" + key);
-                put("from", null);
-                put("value", additionalFields.get(key));
-            }};
-
-            req.add(i);
-        }
-
-        String r = send(RequestMethod.POST, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems",  null, "$"+ encodeSpace(workItemType), ApiVersion.WORK_ITEM_TRACKING,
-                null, null, req, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Deletes the specified work item and sends it to the Recycle Bin, so that it can be restored back, if required.
-      * @param id ID of the work item to be deleted
-     * @return {@link WorkItemDelete}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItemDelete deleteWorkItem(int id) throws ConnectionException, AzDException {
-        String r = send(RequestMethod.DELETE, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems",  String.valueOf(id),null , ApiVersion.WORK_ITEM_TRACKING, null, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemDelete.class);
-    }
-
-    /***
-     * Deletes the specified work item permanently if the destroy parameter has been set to true,
-     * WARNING: If the destroy parameter is set to true, work items deleted by this command will
-     * NOT go to recycle-bin and there is no way to restore/recover them after deletion.
-     * It is recommended NOT to use this parameter. If you do, please use this parameter with extreme caution.
-     * @param id ID of the work item to be deleted
-     * @param destroy Optional parameter, if set to true, the work item is deleted permanently.
-     * Please note: the destroy action is PERMANENT and cannot be undone.
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public void deleteWorkItem(int id, boolean destroy) throws ConnectionException, AzDException {
-        try {
-            var q = new HashMap<String, Object>(){{put("destroy", destroy);}};
-
-            String r = send(RequestMethod.DELETE, CONNECTION, WIT, CONNECTION.getProject(),
-                    AREA + "/workitems",  String.valueOf(id),null , ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-            if (!r.isEmpty()) MAPPER.mapJsonResponse(r, Map.class);
-        } catch (ConnectionException | AzDException e) {
-            throw e;
-        }
-    }
-
-    /***
-     * Returns a single work item.
-     * @param id The work item id
-     * @return WorkItem {@link WorkItem}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItem getWorkItem(int id) throws ConnectionException, AzDException {
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", Integer.toString(id), null, ApiVersion.WORK_ITEM_TRACKING, null, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Returns a single work item.
-     * @param id The work item id
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @return WorkItem {@link WorkItem}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItem getWorkItem(int id, WorkItemExpand expand) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{
-           put("$expand", expand.toString().toLowerCase());
-        }};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", Integer.toString(id), null, ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Returns a single work item.
-     * @param id The work item id
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @param asOf AsOf UTC date time string
-     * @return WorkItem {@link WorkItem}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItem getWorkItem(int id, WorkItemExpand expand, String asOf) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{
-            put("asOf", asOf);
-            put("$expand", expand.toString().toLowerCase());
-        }};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", Integer.toString(id), null, ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Returns a single work item.
-     * @param id The work item id
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @param fields Comma-separated list of requested fields
-     * @return WorkItem {@link WorkItem}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItem getWorkItem(int id, WorkItemExpand expand, String[] fields) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{
-            put("fields", String.join(",", fields));
-            put("$expand", expand.toString().toLowerCase());
-        }};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", Integer.toString(id), null, ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Returns a single work item.
-     * @param id The work item id
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @param fields Comma-separated list of requested fields
-     * @param asOf AsOf UTC date time string
-     * @return WorkItem {@link WorkItem}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItem getWorkItem(int id, WorkItemExpand expand, String[] fields, String asOf) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{
-            put("fields", String.join(",", fields));
-            put("asOf", asOf);
-            put("$expand", expand.toString().toLowerCase());
-        }};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", Integer.toString(id), null, ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Returns a list of work items (Maximum 200)
-     * @param ids Integer array of requested work item ids. (Maximum 200 ids allowed).
-     * @return {@link WorkItemList}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItemList getWorkItems(int[] ids) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{put("ids", intArrayToString(ids));}};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", null, null, ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemList.class);
-    }
-
-    /***
-     * Returns a list of work items (Maximum 200)
-     * @param ids Integer array of requested work item ids. (Maximum 200 ids allowed).
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @return {@link WorkItemList}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItemList getWorkItems(int[] ids, WorkItemExpand expand) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{
-            put("ids", intArrayToString(ids));
-            put("$expand", expand.toString().toLowerCase());
-        }};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", null, null, ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemList.class);
-    }
-
-    /***
-     * Returns a list of work items (Maximum 200)
-     * @param ids Integer array of requested work item ids. (Maximum 200 ids allowed).
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @param asOf AsOf UTC date time string
-     * @return {@link WorkItemList}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String asOf) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{
-            put("ids", intArrayToString(ids));
-            put("$expand", expand.toString().toLowerCase());
-            put("fields", asOf);
-        }};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", null, null, ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemList.class);
-    }
-
-    /***
-     * Returns a list of work items (Maximum 200)
-     * @param ids Integer array of requested work item ids. (Maximum 200 ids allowed).
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @param fields Comma-separated list of requested fields
-     * @return {@link WorkItemList}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String[] fields) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{
-            put("ids", intArrayToString(ids));
-            put("$expand", expand.toString().toLowerCase());
-            put("fields", String.join(",", fields));
-        }};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", null, null, ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemList.class);
-    }
-
-    /***
-     * Returns a list of work items (Maximum 200)
-     * @param ids Integer array of requested work item ids. (Maximum 200 ids allowed).
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @param fields Comma-separated list of requested fields
-     * @param asOf AsOf UTC date time string
-     * @param errorPolicy The flag to control error policy in a bulk get work items request.
-     * Possible options are {Fail, Omit}. {@link WorkItemErrorPolicy}
-     * @return {@link WorkItemList}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String[] fields, String asOf, WorkItemErrorPolicy errorPolicy) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{
-            put("ids", intArrayToString(ids));
-            put("$expand", expand.toString().toLowerCase());
-            put("asOf", asOf);
-            put("fields", String.join(",", fields));
-            put("errorPolicy", errorPolicy.toString().toLowerCase());
-        }};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", null, null, ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemList.class);
-    }
-
-    /***
-     * Returns the list of fully hydrated work item revisions.
-     * @param workItemId The id of the work item
-     * @return {@link WorkItemList}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItemList getWorkItemRevisions(int workItemId) throws ConnectionException, AzDException {
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", Integer.toString(workItemId), "revisions", ApiVersion.WORK_ITEM_TRACKING, null, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemList.class);
-    }
-
-    /***
-     * Returns the list of fully hydrated work item revisions.
-     * @param workItemId The id of the work item
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @return {@link WorkItemList}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItemList getWorkItemRevisions(int workItemId, WorkItemExpand expand) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{put("$expand", expand.toString().toLowerCase());}};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", Integer.toString(workItemId), "revisions", ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemList.class);
-    }
-
-    /***
-     *
-     * Returns the list of fully hydrated work item revisions, paged.
-     * @param workItemId The id of the work item
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @param top Specify top pages to list
-     * @param skip Specify to skip pages
-     * @return {@link WorkItemList}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItemList getWorkItemRevisions(int workItemId, WorkItemExpand expand, int top, int skip) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{
-            put("$expand", expand.toString().toLowerCase());
-            put("$top", top);
-            put("$skip", skip);
-        }};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", Integer.toString(workItemId), "revisions", ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemList.class);
-    }
-
-    /***
-     * Returns a fully hydrated work item for the requested revision
-     * @param workItemId The id of the work item
-     * @param revisionNumber The work item revision number
-     * @return {@link WorkItem}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItem getWorkItemRevision(int workItemId, int revisionNumber) throws ConnectionException, AzDException {
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", Integer.toString(workItemId), "revisions/" + revisionNumber,
-                ApiVersion.WORK_ITEM_TRACKING, null, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Returns a fully hydrated work item for the requested revision
-     * @param workItemId The id of the work item
-     * @param revisionNumber The work item revision number
-     * @param expand The expand parameters for work item attributes.
-     * Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @return {@link WorkItem}
-     * @throws ConnectionException A connection object should be created with Azure DevOps organization name, personal access token
-     * and project. This validates the connection object and throws exception if it is not provided.
-     * @throws AzDException Default Api Exception handler.
-     */
-    @Override
-    public WorkItem getWorkItemRevision(int workItemId, int revisionNumber, WorkItemExpand expand) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{put("$expand", expand.toString().toLowerCase());}};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems", Integer.toString(workItemId), "revisions/" + revisionNumber,
-                ApiVersion.WORK_ITEM_TRACKING, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Gets the results of the query given its WIQL.
-     * @param team Team ID or team name
-     * @param query Specify the query to list the work items. E.g., "Select * From WorkItems Where [System.WorkItemType] = 'User Story'"
-     * @return WorkItemQueryResult {@link WorkItemQueryResult}
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public WorkItemQueryResult queryByWiql(String team, String query) throws ConnectionException, AzDException {
-        var body = new HashMap<String, Object>(){{put("query", query);}};
-
-        String r = send(RequestMethod.POST, CONNECTION, WIT, CONNECTION.getProject() + "/" + encodeSpace(team),
-                AREA, null, "wiql", ApiVersion.WIT_WIQL, null, body);
-
-        return MAPPER.mapJsonResponse(r, WorkItemQueryResult.class);
-    }
-
-    /***
-     * Gets the results of the query given its WIQL.
-     * @param team Team ID or team name
-     * @param query Specify the query to list the work items. E.g., "Select * From WorkItems Where [System.WorkItemType] = 'User Story'"
-     * @param top The max number of results to return.
-     * @param timePrecision The max number of results to return.
-     * @return WorkItemQueryResult {@link WorkItemQueryResult}
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public WorkItemQueryResult queryByWiql(String team, String query, int top, boolean timePrecision) throws ConnectionException, AzDException {
-        var body = new HashMap<String, Object>(){{put("query", query);}};
-
-        var q = new HashMap<String, Object>(){{
-            put("$top", top);
-            put("timePrecision", timePrecision);
-        }};
-
-        String r = send(RequestMethod.POST, CONNECTION, WIT, CONNECTION.getProject() + "/" + encodeSpace(team),
-                AREA, null, "wiql", ApiVersion.WIT_WIQL, q, body);
-
-        return MAPPER.mapJsonResponse(r, WorkItemQueryResult.class);
-    }
-
-    /***
-     * Destroys the specified work item permanently from the Recycle Bin. This action can not be undone.
-     * @param id ID of the work item to be destroyed permanently
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public void removeWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException {
-        try {
-            String r = send(RequestMethod.DELETE, CONNECTION, WIT, CONNECTION.getProject(),
-                    AREA + "/recyclebin", Integer.toString(id), null, ApiVersion.WIT_RECYCLE_BIN, null, null);
-            if (!r.isEmpty()) MAPPER.mapJsonResponse(r, Map.class);
-        } catch (ConnectionException | AzDException e) {
-            throw e;
-        }
-    }
-
-    /***
-     * Gets a deleted work item from Recycle Bin.
-     * @param id ID of the work item to be returned
-     * @return WorkItemDeleteReference {@link WorkItemDeleteReference}
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public WorkItemDeleteReference getWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException {
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/recyclebin", Integer.toString(id), null, ApiVersion.WIT_RECYCLE_BIN, null, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemDeleteReference.class);
-    }
-
-    /***
-     * Gets a list of the IDs and the URLs of the deleted the work items in the Recycle Bin.
-     * @return WorkItemDeleteShallowReferences {@link WorkItemDeleteShallowReferences}
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public WorkItemDeleteShallowReferences getDeletedWorkItemsFromRecycleBin() throws ConnectionException, AzDException {
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/recyclebin", null, null, ApiVersion.WIT_RECYCLE_BIN, null, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemDeleteShallowReferences.class);
-    }
-
-    /***
-     * Gets the work items from the recycle bin, whose IDs have been specified in the parameters
-     * @param ids array of workitem ids
-     * @return WorkItemDeleteReferences {@link WorkItemDeleteReferences}
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public WorkItemDeleteReferences getDeletedWorkItemsFromRecycleBin(int[] ids) throws ConnectionException, AzDException {
-        var q = new HashMap<String, Object>(){{
-           put("ids", intArrayToString(ids));
-        }};
-
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/recyclebin", null, null, ApiVersion.WIT_RECYCLE_BIN, q, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemDeleteReferences.class);
-    }
-
-    /***
-     * Restores the deleted work item from Recycle Bin.
-     * @param id ID of the work item to be restored
-     * @return WorkItemDeleteReference {@link WorkItemDeleteReference}
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public WorkItemDeleteReference restoreWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException {
-        var b = new HashMap<String, Object>(){{
-            put("isDeleted", false);
-        }};
-
-        String r = send(RequestMethod.PATCH, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/recyclebin", Integer.toString(id), null, ApiVersion.WIT_RECYCLE_BIN, null, b);
-
-        return MAPPER.mapJsonResponse(r, WorkItemDeleteReference.class);
-    }
-
-    /***
-     * Update a single work item with the internal field names.
-     * @param workItemId The id of the work item to update
-     * @param fieldsToUpdate HashMap of internal field names to update. E.g., System.Title, System.Description etc and it's associated values.
-     * @return WorkItemDeleteReference {@link WorkItemDeleteReference}
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public WorkItem updateWorkItem(int workItemId, HashMap<String, Object> fieldsToUpdate) throws ConnectionException, AzDException {
-        var req = new ArrayList<>();
-
-        for (var key : fieldsToUpdate.keySet()) {
-            var i = new HashMap<String, Object>(){{
-                put("op", "add");
-                put("path", "/fields/" + key);
-                put("from", null);
-                put("value", fieldsToUpdate.get(key));
-            }};
-
-            req.add(i);
-        }
-
-        String r = send(RequestMethod.PATCH, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems",  Integer.toString(workItemId), null, ApiVersion.WORK_ITEM_TRACKING,
-                null, null, req, "application/json-patch+json; charset=utf-8");
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Update a single work item with the internal field names.
-     * @param workItemId The id of the work item to update
-     * @param expand The expand parameters for work item attributes. Possible options are { None, Relations, Fields, Links, All }. {@link WorkItemExpand}
-     * @param bypassRules Do not enforce the work item type rules on this update
-     * @param suppressNotifications Do not fire any notifications for this change
-     * @param validateOnly Indicate if you only want to validate the changes without saving the work item
-     * @param fieldsToUpdate HashMap of internal field names to update. E.g., System.Title, System.Description etc and it's associated values.
-     * @return WorkItemDeleteReference {@link WorkItemDeleteReference}
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public WorkItem updateWorkItem(int workItemId, WorkItemExpand expand, boolean bypassRules, boolean suppressNotifications,
-                                   boolean validateOnly, HashMap<String, Object> fieldsToUpdate) throws ConnectionException, AzDException {
-        var req = new ArrayList<>();
-
-        for (var key : fieldsToUpdate.keySet()) {
-            var i = new HashMap<String, Object>(){{
-                put("op", "add");
-                put("path", "/fields/" + key);
-                put("from", null);
-                put("value", fieldsToUpdate.get(key));
-            }};
-
-            req.add(i);
-        }
-
-        var q = new HashMap<String, Object>(){{
-            put("validateOnly", validateOnly);
-            put("bypassRules", bypassRules);
-            put("suppressNotifications", suppressNotifications);
-            put("$expand", expand.toString().toLowerCase());
-        }};
-
-        String r = send(RequestMethod.PATCH, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA + "/workitems",  Integer.toString(workItemId), null, ApiVersion.WORK_ITEM_TRACKING,
-                q, null, req, "application/json-patch+json; charset=utf-8");
-
-        return MAPPER.mapJsonResponse(r, WorkItem.class);
-    }
-
-    /***
-     * Returns the list of work item types
-     * @return list of Work Item type {@link WorkItemTypes}
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public WorkItemTypes getWorkItemTypes() throws ConnectionException, AzDException {
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA,  null, "workitemtypes", ApiVersion.WORK_ITEM_TYPES, null, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemTypes.class);
-    }
-
-    /***
-     * Returns a work item type definition.
-     * @param workItemTypeName provide the work item type name. e.g., Bug or user story etc.
-     * @return work item type {@link WorkItemType}
-     * @throws ConnectionException set the default parameters organization name, project name and
-     * personal access token to work with any API in this library.
-     * @throws AzDException Handles errors from REST API and validates passed arguments
-     */
-    @Override
-    public WorkItemType getWorkItemType(String workItemTypeName) throws ConnectionException, AzDException {
-        String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(),
-                AREA,  null, "workitemtypes/" + workItemTypeName, ApiVersion.WORK_ITEM_TYPES, null, null);
-
-        return MAPPER.mapJsonResponse(r, WorkItemType.class);
-    }
-
-    /***
-     * Helper method to convert integer array to string.
-     * @param i integer array
-     * @return {@link String}
-     */
-    private String intArrayToString(int[] i) {
-        var r = Arrays.stream(i).mapToObj(String::valueOf).toArray(String[]::new);
-        return String.join(",", r);
-    }
+
+	/***
+	 * Connection object
+	 */
+	private final Connection CONNECTION;
+
+	private final JsonMapper MAPPER = new JsonMapper();
+
+	private final String AREA = "wit";
+
+	private final String WIT = "5264459e-e5e0-4bd8-b118-0985e68a4ec5";
+
+	/***
+	 * Pass the connection object to work with WorkItem Tracking Api
+	 *
+	 * @param connection
+	 *            Connection object
+	 */
+	public WorkItemTrackingApi(Connection connection) {
+		CONNECTION = connection;
+	}
+
+	/***
+	 * Creates a single work item.
+	 *
+	 * @param workItemType
+	 *            The work item type of the work item to create. e.g., "user
+	 *            story", "bug", "task"
+	 * @param operation
+	 *            The patch operation {@link WorkItemOperation}
+	 * @param title
+	 *            The title for the work item
+	 * @return {@link WorkItem}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItem createWorkItem(String workItemType, WorkItemOperation operation, String title)
+			throws ConnectionException, AzDException {
+		var req = new HashMap<String, Object>() {
+
+			{
+				put("op", operation.toString().toLowerCase());
+				put("path", "/fields/System.Title");
+				put("from", null);
+				put("value", title);
+			}
+		};
+
+		String r = send(RequestMethod.POST, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems", null,
+				"$" + encodeSpace(workItemType), ApiVersion.WORK_ITEM_TRACKING, null, null, List.of(req), null);
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	/***
+	 * Creates a single work item.
+	 *
+	 * @param workItemType
+	 *            The work item type of the work item to create. e.g., "user
+	 *            story", "bug", "task"
+	 * @param operation
+	 *            The patch operation {@link WorkItemOperation}
+	 * @param title
+	 *            The title for the work item
+	 * @param description
+	 *            Description for the work item
+	 * @param tags
+	 *            Tags for the work item
+	 * @return {@link WorkItem}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItem createWorkItem(String workItemType, WorkItemOperation operation, String title, String description,
+			String[] tags) throws ConnectionException, AzDException {
+		var t = new HashMap<String, Object>() {
+
+			{
+				put("op", operation.toString().toLowerCase());
+				put("path", "/fields/System.Title");
+				put("from", null);
+				put("value", title);
+			}
+		};
+
+		var d = new HashMap<String, Object>() {
+
+			{
+				put("op", operation.toString().toLowerCase());
+				put("path", "/fields/System.Description");
+				put("from", null);
+				put("value", description);
+			}
+		};
+
+		var tt = new HashMap<String, Object>() {
+
+			{
+				put("op", operation.toString().toLowerCase());
+				put("path", "/fields/System.Tags");
+				put("from", null);
+				put("value", String.join(",", tags));
+			}
+		};
+
+		var req = new ArrayList<>();
+		req.add(t);
+		req.add(d);
+		req.add(tt);
+
+		String r = send(RequestMethod.POST, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems", null,
+				"$" + encodeSpace(workItemType), ApiVersion.WORK_ITEM_TRACKING, null, null, req, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	/***
+	 * Creates a single work item optionally with additional fields.
+	 *
+	 * @param workItemType
+	 *            The work item type of the work item to create. e.g., "user
+	 *            story", "bug", "task"
+	 * @param title
+	 *            The title for the work item
+	 * @param description
+	 *            Description for the work item
+	 * @param additionalFields
+	 *            Provide the additional fields as a HashMap to create the work
+	 *            item. This requires the internal fields to be specified. E.g.,
+	 *            System.Tags, System.AreaPath, System.State, System.Reason
+	 *            etc.,
+	 * @return {@link WorkItem}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItem createWorkItem(String workItemType, String title, String description,
+			HashMap<String, Object> additionalFields) throws ConnectionException, AzDException {
+		var req = new ArrayList<>();
+
+		var t = new HashMap<String, Object>() {
+
+			{
+				put("op", "add");
+				put("path", "/fields/System.Title");
+				put("from", null);
+				put("value", title);
+			}
+		};
+
+		var d = new HashMap<String, Object>() {
+
+			{
+				put("op", "add");
+				put("path", "/fields/System.Description");
+				put("from", null);
+				put("value", description);
+			}
+		};
+
+		req.add(t);
+		req.add(d);
+
+		for (var key : additionalFields.keySet()) {
+			var i = new HashMap<String, Object>() {
+
+				{
+					put("op", "add");
+					put("path", "/fields/" + key);
+					put("from", null);
+					put("value", additionalFields.get(key));
+				}
+			};
+
+			req.add(i);
+		}
+
+		String r = send(RequestMethod.POST, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems", null,
+				"$" + encodeSpace(workItemType), ApiVersion.WORK_ITEM_TRACKING, null, null, req, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	/***
+	 * Deletes the specified work item and sends it to the Recycle Bin, so that
+	 * it can be restored back, if required.
+	 *
+	 * @param id
+	 *            ID of the work item to be deleted
+	 * @return {@link WorkItemDelete}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItemDelete deleteWorkItem(int id) throws ConnectionException, AzDException {
+		String r = send(RequestMethod.DELETE, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				String.valueOf(id), null, ApiVersion.WORK_ITEM_TRACKING, null, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemDelete.class);
+	}
+
+	/***
+	 * Deletes the specified work item permanently if the destroy parameter has
+	 * been set to true, WARNING: If the destroy parameter is set to true, work
+	 * items deleted by this command will NOT go to recycle-bin and there is no
+	 * way to restore/recover them after deletion. It is recommended NOT to use
+	 * this parameter. If you do, please use this parameter with extreme
+	 * caution.
+	 *
+	 * @param id
+	 *            ID of the work item to be deleted
+	 * @param destroy
+	 *            Optional parameter, if set to true, the work item is deleted
+	 *            permanently. Please note: the destroy action is PERMANENT and
+	 *            cannot be undone.
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public void deleteWorkItem(int id, boolean destroy) throws ConnectionException, AzDException {
+		try {
+			var q = new HashMap<String, Object>() {
+
+				{
+					put("destroy", destroy);
+				}
+			};
+
+			String r = send(RequestMethod.DELETE, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+					String.valueOf(id), null, ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+			if (!r.isEmpty()) {
+				MAPPER.mapJsonResponse(r, Map.class);
+			}
+		} catch (ConnectionException | AzDException e) {
+			throw e;
+		}
+	}
+
+	/***
+	 * Returns a single work item.
+	 *
+	 * @param id
+	 *            The work item id
+	 * @return WorkItem {@link WorkItem}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItem getWorkItem(int id) throws ConnectionException, AzDException {
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(id), null, ApiVersion.WORK_ITEM_TRACKING, null, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	/***
+	 * Returns a single work item.
+	 *
+	 * @param id
+	 *            The work item id
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @return WorkItem {@link WorkItem}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItem getWorkItem(int id, WorkItemExpand expand) throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("$expand", expand.toString().toLowerCase());
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(id), null, ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	/***
+	 * Returns a single work item.
+	 *
+	 * @param id
+	 *            The work item id
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @param asOf
+	 *            AsOf UTC date time string
+	 * @return WorkItem {@link WorkItem}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItem getWorkItem(int id, WorkItemExpand expand, String asOf) throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("asOf", asOf);
+				put("$expand", expand.toString().toLowerCase());
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(id), null, ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	/***
+	 * Returns a single work item.
+	 *
+	 * @param id
+	 *            The work item id
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @param fields
+	 *            Comma-separated list of requested fields
+	 * @return WorkItem {@link WorkItem}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItem getWorkItem(int id, WorkItemExpand expand, String[] fields)
+			throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("fields", String.join(",", fields));
+				put("$expand", expand.toString().toLowerCase());
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(id), null, ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	/***
+	 * Returns a single work item.
+	 *
+	 * @param id
+	 *            The work item id
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @param fields
+	 *            Comma-separated list of requested fields
+	 * @param asOf
+	 *            AsOf UTC date time string
+	 * @return WorkItem {@link WorkItem}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItem getWorkItem(int id, WorkItemExpand expand, String[] fields, String asOf)
+			throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("fields", String.join(",", fields));
+				put("asOf", asOf);
+				put("$expand", expand.toString().toLowerCase());
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(id), null, ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	/***
+	 * Returns a list of work items (Maximum 200)
+	 *
+	 * @param ids
+	 *            Integer array of requested work item ids. (Maximum 200 ids
+	 *            allowed).
+	 * @return {@link WorkItemList}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItemList getWorkItems(int[] ids) throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("ids", intArrayToString(ids));
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems", null, null,
+				ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemList.class);
+	}
+
+	/***
+	 * Returns a list of work items (Maximum 200)
+	 *
+	 * @param ids
+	 *            Integer array of requested work item ids. (Maximum 200 ids
+	 *            allowed).
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @return {@link WorkItemList}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItemList getWorkItems(int[] ids, WorkItemExpand expand) throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("ids", intArrayToString(ids));
+				put("$expand", expand.toString().toLowerCase());
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems", null, null,
+				ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemList.class);
+	}
+
+	/***
+	 * Returns a list of work items (Maximum 200)
+	 *
+	 * @param ids
+	 *            Integer array of requested work item ids. (Maximum 200 ids
+	 *            allowed).
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @param asOf
+	 *            AsOf UTC date time string
+	 * @return {@link WorkItemList}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String asOf)
+			throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("ids", intArrayToString(ids));
+				put("$expand", expand.toString().toLowerCase());
+				put("fields", asOf);
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems", null, null,
+				ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemList.class);
+	}
+
+	/***
+	 * Returns a list of work items (Maximum 200)
+	 *
+	 * @param ids
+	 *            Integer array of requested work item ids. (Maximum 200 ids
+	 *            allowed).
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @param fields
+	 *            Comma-separated list of requested fields
+	 * @return {@link WorkItemList}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String[] fields)
+			throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("ids", intArrayToString(ids));
+				put("$expand", expand.toString().toLowerCase());
+				put("fields", String.join(",", fields));
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems", null, null,
+				ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemList.class);
+	}
+
+	/***
+	 * Returns a list of work items (Maximum 200)
+	 *
+	 * @param ids
+	 *            Integer array of requested work item ids. (Maximum 200 ids
+	 *            allowed).
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @param fields
+	 *            Comma-separated list of requested fields
+	 * @param asOf
+	 *            AsOf UTC date time string
+	 * @param errorPolicy
+	 *            The flag to control error policy in a bulk get work items
+	 *            request. Possible options are {Fail, Omit}.
+	 *            {@link WorkItemErrorPolicy}
+	 * @return {@link WorkItemList}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItemList getWorkItems(int[] ids, WorkItemExpand expand, String[] fields, String asOf,
+			WorkItemErrorPolicy errorPolicy) throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("ids", intArrayToString(ids));
+				put("$expand", expand.toString().toLowerCase());
+				put("asOf", asOf);
+				put("fields", String.join(",", fields));
+				put("errorPolicy", errorPolicy.toString().toLowerCase());
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems", null, null,
+				ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemList.class);
+	}
+
+	/***
+	 * Returns the list of fully hydrated work item revisions.
+	 *
+	 * @param workItemId
+	 *            The id of the work item
+	 * @return {@link WorkItemList}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItemList getWorkItemRevisions(int workItemId) throws ConnectionException, AzDException {
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(workItemId), "revisions", ApiVersion.WORK_ITEM_TRACKING, null, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemList.class);
+	}
+
+	/***
+	 * Returns the list of fully hydrated work item revisions.
+	 *
+	 * @param workItemId
+	 *            The id of the work item
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @return {@link WorkItemList}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItemList getWorkItemRevisions(int workItemId, WorkItemExpand expand)
+			throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("$expand", expand.toString().toLowerCase());
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(workItemId), "revisions", ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemList.class);
+	}
+
+	/***
+	 *
+	 * Returns the list of fully hydrated work item revisions, paged.
+	 *
+	 * @param workItemId
+	 *            The id of the work item
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @param top
+	 *            Specify top pages to list
+	 * @param skip
+	 *            Specify to skip pages
+	 * @return {@link WorkItemList}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItemList getWorkItemRevisions(int workItemId, WorkItemExpand expand, int top, int skip)
+			throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("$expand", expand.toString().toLowerCase());
+				put("$top", top);
+				put("$skip", skip);
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(workItemId), "revisions", ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemList.class);
+	}
+
+	/***
+	 * Returns a fully hydrated work item for the requested revision
+	 *
+	 * @param workItemId
+	 *            The id of the work item
+	 * @param revisionNumber
+	 *            The work item revision number
+	 * @return {@link WorkItem}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItem getWorkItemRevision(int workItemId, int revisionNumber) throws ConnectionException, AzDException {
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(workItemId), "revisions/" + revisionNumber, ApiVersion.WORK_ITEM_TRACKING, null, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	/***
+	 * Returns a fully hydrated work item for the requested revision
+	 *
+	 * @param workItemId
+	 *            The id of the work item
+	 * @param revisionNumber
+	 *            The work item revision number
+	 * @param expand
+	 *            The expand parameters for work item attributes. Possible
+	 *            options are { None, Relations, Fields, Links, All }.
+	 *            {@link WorkItemExpand}
+	 * @return {@link WorkItem}
+	 * @throws ConnectionException
+	 *             A connection object should be created with Azure DevOps
+	 *             organization name, personal access token and project. This
+	 *             validates the connection object and throws exception if it is
+	 *             not provided.
+	 * @throws AzDException
+	 *             Default Api Exception handler.
+	 */
+	@Override
+	public WorkItem getWorkItemRevision(int workItemId, int revisionNumber, WorkItemExpand expand)
+			throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("$expand", expand.toString().toLowerCase());
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(workItemId), "revisions/" + revisionNumber, ApiVersion.WORK_ITEM_TRACKING, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	/***
+	 * Gets the results of the query given its WIQL.
+	 *
+	 * @param team
+	 *            Team ID or team name
+	 * @param query
+	 *            Specify the query to list the work items. E.g., "Select * From
+	 *            WorkItems Where [System.WorkItemType] = 'User Story'"
+	 * @return WorkItemQueryResult {@link WorkItemQueryResult}
+	 * @throws ConnectionException
+	 *             set the default parameters organization name, project name
+	 *             and personal access token to work with any API in this
+	 *             library.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments
+	 */
+	@Override
+	public WorkItemQueryResult queryByWiql(String team, String query) throws ConnectionException, AzDException {
+		var body = new HashMap<String, Object>() {
+
+			{
+				put("query", query);
+			}
+		};
+
+		String r = send(RequestMethod.POST, CONNECTION, WIT, CONNECTION.getProject() + "/" + encodeSpace(team), AREA,
+				null, "wiql", ApiVersion.WIT_WIQL, null, body);
+
+		return MAPPER.mapJsonResponse(r, WorkItemQueryResult.class);
+	}
+
+	/***
+	 * Gets the results of the query given its WIQL.
+	 *
+	 * @param team
+	 *            Team ID or team name
+	 * @param query
+	 *            Specify the query to list the work items. E.g., "Select * From
+	 *            WorkItems Where [System.WorkItemType] = 'User Story'"
+	 * @param top
+	 *            The max number of results to return.
+	 * @param timePrecision
+	 *            The max number of results to return.
+	 * @return WorkItemQueryResult {@link WorkItemQueryResult}
+	 * @throws ConnectionException
+	 *             set the default parameters organization name, project name
+	 *             and personal access token to work with any API in this
+	 *             library.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments
+	 */
+	@Override
+	public WorkItemQueryResult queryByWiql(String team, String query, int top, boolean timePrecision)
+			throws ConnectionException, AzDException {
+		var body = new HashMap<String, Object>() {
+
+			{
+				put("query", query);
+			}
+		};
+
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("$top", top);
+				put("timePrecision", timePrecision);
+			}
+		};
+
+		String r = send(RequestMethod.POST, CONNECTION, WIT, CONNECTION.getProject() + "/" + encodeSpace(team), AREA,
+				null, "wiql", ApiVersion.WIT_WIQL, q, body);
+
+		return MAPPER.mapJsonResponse(r, WorkItemQueryResult.class);
+	}
+
+	/***
+	 * Destroys the specified work item permanently from the Recycle Bin. This
+	 * action can not be undone.
+	 *
+	 * @param id
+	 *            ID of the work item to be destroyed permanently
+	 * @throws ConnectionException
+	 *             set the default parameters organization name, project name
+	 *             and personal access token to work with any API in this
+	 *             library.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments
+	 */
+	@Override
+	public void removeWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException {
+		try {
+			String r = send(RequestMethod.DELETE, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/recyclebin",
+					Integer.toString(id), null, ApiVersion.WIT_RECYCLE_BIN, null, null);
+			if (!r.isEmpty()) {
+				MAPPER.mapJsonResponse(r, Map.class);
+			}
+		} catch (ConnectionException | AzDException e) {
+			throw e;
+		}
+	}
+
+	/***
+	 * Gets a deleted work item from Recycle Bin.
+	 *
+	 * @param id
+	 *            ID of the work item to be returned
+	 * @return WorkItemDeleteReference {@link WorkItemDeleteReference}
+	 * @throws ConnectionException
+	 *             set the default parameters organization name, project name
+	 *             and personal access token to work with any API in this
+	 *             library.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments
+	 */
+	@Override
+	public WorkItemDeleteReference getWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException {
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/recyclebin",
+				Integer.toString(id), null, ApiVersion.WIT_RECYCLE_BIN, null, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemDeleteReference.class);
+	}
+
+	/***
+	 * Gets a list of the IDs and the URLs of the deleted the work items in the
+	 * Recycle Bin.
+	 *
+	 * @return WorkItemDeleteShallowReferences
+	 *         {@link WorkItemDeleteShallowReferences}
+	 * @throws ConnectionException
+	 *             set the default parameters organization name, project name
+	 *             and personal access token to work with any API in this
+	 *             library.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments
+	 */
+	@Override
+	public WorkItemDeleteShallowReferences getDeletedWorkItemsFromRecycleBin()
+			throws ConnectionException, AzDException {
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/recyclebin", null, null,
+				ApiVersion.WIT_RECYCLE_BIN, null, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemDeleteShallowReferences.class);
+	}
+
+	/***
+	 * Gets the work items from the recycle bin, whose IDs have been specified
+	 * in the parameters
+	 *
+	 * @param ids
+	 *            array of workitem ids
+	 * @return WorkItemDeleteReferences {@link WorkItemDeleteReferences}
+	 * @throws ConnectionException
+	 *             set the default parameters organization name, project name
+	 *             and personal access token to work with any API in this
+	 *             library.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments
+	 */
+	@Override
+	public WorkItemDeleteReferences getDeletedWorkItemsFromRecycleBin(int[] ids)
+			throws ConnectionException, AzDException {
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("ids", intArrayToString(ids));
+			}
+		};
+
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/recyclebin", null, null,
+				ApiVersion.WIT_RECYCLE_BIN, q, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemDeleteReferences.class);
+	}
+
+	/***
+	 * Restores the deleted work item from Recycle Bin.
+	 *
+	 * @param id
+	 *            ID of the work item to be restored
+	 * @return WorkItemDeleteReference {@link WorkItemDeleteReference}
+	 * @throws ConnectionException
+	 *             set the default parameters organization name, project name
+	 *             and personal access token to work with any API in this
+	 *             library.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments
+	 */
+	@Override
+	public WorkItemDeleteReference restoreWorkItemFromRecycleBin(int id) throws ConnectionException, AzDException {
+		var b = new HashMap<String, Object>() {
+
+			{
+				put("isDeleted", false);
+			}
+		};
+
+		String r = send(RequestMethod.PATCH, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/recyclebin",
+				Integer.toString(id), null, ApiVersion.WIT_RECYCLE_BIN, null, b);
+
+		return MAPPER.mapJsonResponse(r, WorkItemDeleteReference.class);
+	}
+
+	@Override
+	public WorkItem updateWorkItem(int workItemId, HashMap<String, Object> fieldsToUpdate)
+			throws ConnectionException, AzDException {
+
+		return updateWorkItem(workItemId, fieldsToUpdate, WorkItemOperation.ADD);
+	}
+
+	@Override
+	public WorkItem updateWorkItem(int workItemId, HashMap<String, Object> fieldsToUpdate, WorkItemOperation operation)
+			throws ConnectionException, AzDException {
+
+		var req = new ArrayList<>();
+
+		for (var key : fieldsToUpdate.keySet()) {
+			var i = new HashMap<String, Object>() {
+
+				{
+					put("op", operation.name().toLowerCase());
+					put("path", "/fields/" + key);
+					put("from", null);
+					if (operation != WorkItemOperation.REMOVE) {
+						put("value", fieldsToUpdate.get(key));
+					}
+				}
+			};
+
+			req.add(i);
+		}
+
+		String r = send(RequestMethod.PATCH, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(workItemId), null, ApiVersion.WORK_ITEM_TRACKING, null, null, req,
+				"application/json-patch+json; charset=utf-8");
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	@Override
+	public WorkItem updateWorkItem(int workItemId, WorkItemExpand expand, boolean bypassRules,
+			boolean suppressNotifications, boolean validateOnly, HashMap<String, Object> fieldsToUpdate)
+			throws ConnectionException, AzDException {
+
+		return updateWorkItem(workItemId, expand, bypassRules, suppressNotifications, validateOnly, fieldsToUpdate,
+				WorkItemOperation.ADD);
+	}
+
+	@Override
+	public WorkItem updateWorkItem(int workItemId, WorkItemExpand expand, boolean bypassRules,
+			boolean suppressNotifications, boolean validateOnly, HashMap<String, Object> fieldsToUpdate,
+			WorkItemOperation operation) throws ConnectionException, AzDException {
+
+		var req = new ArrayList<>();
+
+		for (var key : fieldsToUpdate.keySet()) {
+			var i = new HashMap<String, Object>() {
+
+				{
+					put("op", operation.name().toLowerCase());
+					put("path", "/fields/" + key);
+					put("from", null);
+					if (operation != WorkItemOperation.REMOVE) {
+						put("value", fieldsToUpdate.get(key));
+					}
+				}
+			};
+
+			req.add(i);
+		}
+
+		var q = new HashMap<String, Object>() {
+
+			{
+				put("validateOnly", validateOnly);
+				put("bypassRules", bypassRules);
+				put("suppressNotifications", suppressNotifications);
+				put("$expand", expand.toString().toLowerCase());
+			}
+		};
+
+		String r = send(RequestMethod.PATCH, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(workItemId), null, ApiVersion.WORK_ITEM_TRACKING, q, null, req,
+				"application/json-patch+json; charset=utf-8");
+
+		return MAPPER.mapJsonResponse(r, WorkItem.class);
+	}
+
+	@Override
+	public WorkItem addHyperLinks(int workItemId, Map<String, String> hyperlinksMap)
+			throws ConnectionException, AzDException {
+
+		List<Object> reqBody = new ArrayList<>();
+
+		for (Entry<String, String> hyperlinkEntry : hyperlinksMap.entrySet()) {
+			String url = hyperlinkEntry.getKey();
+			String comment = hyperlinkEntry.getValue();
+
+			Map<String, Object> attributesMap = null;
+			if (comment != null && !comment.isEmpty()) {
+				attributesMap = new HashMap<>();
+				attributesMap.put("comment", comment);
+			}
+
+			Map<String, Object> hyperlinkMap = new HashMap<>();
+			hyperlinkMap.put("rel", "Hyperlink");
+			hyperlinkMap.put("url", url);
+			if (attributesMap != null) {
+				hyperlinkMap.put("attributes", attributesMap);
+			}
+
+			Map<String, Object> reqBodyMap = new HashMap<>();
+			reqBodyMap.put("op", WorkItemOperation.ADD.name().toLowerCase());
+			reqBodyMap.put("path", "/relations/-");
+			reqBodyMap.put("value", hyperlinkMap);
+
+			reqBody.add(reqBodyMap);
+		}
+
+		String reply = send(RequestMethod.PATCH, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(workItemId), null, ApiVersion.WORK_ITEM_TRACKING, null, null, reqBody,
+				"application/json-patch+json; charset=utf-8");
+
+		return MAPPER.mapJsonResponse(reply, WorkItem.class);
+	}
+
+	@Override
+	public WorkItem removeHyperLinks(int workItemId, List<String> urls) throws ConnectionException, AzDException {
+
+		List<Object> reqBody = new ArrayList<>();
+
+		List<WorkItemRelations> relations = getWorkItem(workItemId, WorkItemExpand.RELATIONS).getRelations();
+
+		for (String url : urls) {
+			int hyperlinkRelationNumber = -1;
+			for (int i = 0; i < relations.size(); i++) {
+				WorkItemRelations workItemRelations = relations.get(i);
+				if (!workItemRelations.getRel().equals("Hyperlink")) {
+					continue;
+				}
+
+				if (workItemRelations.getUrl().equals(url)) {
+					hyperlinkRelationNumber = i;
+
+					break;
+				}
+			}
+
+			if (hyperlinkRelationNumber == -1) {
+				throw new AzDException(MessageFormat.format(
+						"Unable to remove hyperlink ''{0}'' from work item with ID ''{1}'': The hyperlink doesn''t exist.",
+						url, hyperlinkRelationNumber));
+			}
+
+			Map<String, Object> reqBodyMap = new HashMap<>();
+			reqBodyMap.put("op", WorkItemOperation.REMOVE.name().toLowerCase());
+			reqBodyMap.put("path", "/relations/" + Integer.toString(hyperlinkRelationNumber));
+
+			reqBody.add(reqBodyMap);
+		}
+
+		String reply = send(RequestMethod.PATCH, CONNECTION, WIT, CONNECTION.getProject(), AREA + "/workitems",
+				Integer.toString(workItemId), null, ApiVersion.WORK_ITEM_TRACKING, null, null, reqBody,
+				"application/json-patch+json; charset=utf-8");
+
+		return MAPPER.mapJsonResponse(reply, WorkItem.class);
+	}
+
+	/***
+	 * Returns the list of work item types
+	 *
+	 * @return list of Work Item type {@link WorkItemTypes}
+	 * @throws ConnectionException
+	 *             set the default parameters organization name, project name
+	 *             and personal access token to work with any API in this
+	 *             library.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments
+	 */
+	@Override
+	public WorkItemTypes getWorkItemTypes() throws ConnectionException, AzDException {
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA, null, "workitemtypes",
+				ApiVersion.WORK_ITEM_TYPES, null, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemTypes.class);
+	}
+
+	/***
+	 * Returns a work item type definition.
+	 *
+	 * @param workItemTypeName
+	 *            provide the work item type name. e.g., Bug or user story etc.
+	 * @return work item type {@link WorkItemType}
+	 * @throws ConnectionException
+	 *             set the default parameters organization name, project name
+	 *             and personal access token to work with any API in this
+	 *             library.
+	 * @throws AzDException
+	 *             Handles errors from REST API and validates passed arguments
+	 */
+	@Override
+	public WorkItemType getWorkItemType(String workItemTypeName) throws ConnectionException, AzDException {
+		String r = send(RequestMethod.GET, CONNECTION, WIT, CONNECTION.getProject(), AREA, null,
+				"workitemtypes/" + workItemTypeName, ApiVersion.WORK_ITEM_TYPES, null, null);
+
+		return MAPPER.mapJsonResponse(r, WorkItemType.class);
+	}
+
+	/***
+	 * Helper method to convert integer array to string.
+	 *
+	 * @param i
+	 *            integer array
+	 * @return {@link String}
+	 */
+	private String intArrayToString(int[] i) {
+		var r = Arrays.stream(i).mapToObj(String::valueOf).toArray(String[]::new);
+		return String.join(",", r);
+	}
 }

--- a/azd/src/test/java/org/azd/WorkItemTrackingApiTest.java
+++ b/azd/src/test/java/org/azd/WorkItemTrackingApiTest.java
@@ -1,5 +1,13 @@
 package org.azd;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.azd.enums.WorkItemExpand;
 import org.azd.enums.WorkItemOperation;
 import org.azd.exceptions.AzDException;
@@ -11,137 +19,167 @@ import org.azd.workitemtracking.WorkItemTrackingApi;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
-import java.util.HashMap;
-
-import static org.junit.Assert.assertEquals;
-
 public class WorkItemTrackingApiTest {
-    private static final JsonMapper MAPPER = new JsonMapper();
-    private static AzDClient webApi;
-    private static WorkItemTrackingApi w;
 
-    @Before
-    public void init() throws AzDException {
-        String dir = System.getProperty("user.dir");
-        File file = new File(dir + "/src/test/java/org/azd/_unitTest.json");
-        MockParameters m = MAPPER.mapJsonFromFile(file, MockParameters.class);
-        String organization = m.getO();
-        String token = m.getT();
-        String project = m.getP();
-        webApi = new AzDClientApi(organization, project, token);
-        w = webApi.getWorkItemTrackingApi();
-    }
+	private static final JsonMapper MAPPER = new JsonMapper();
 
-    @Test
-    public void shouldGetWorkItem() throws ConnectionException, AzDException {
-        var expectedValue = "azure-devops-java-sdk";
-        var result = w.getWorkItem(2).getFields().getSystemTeamProject();
-        assertEquals(expectedValue, result);
-    }
+	private static AzDClient webApi;
 
-    @Test
-    public void shouldGetWorkItemWithOptionalParameters() throws ConnectionException, AzDException {
-        var expectedValue = "azure-devops-java-sdk";
-        var result = w.getWorkItem(2, WorkItemExpand.ALL).getFields().getSystemTeamProject();
-        assertEquals(expectedValue, result);
-    }
+	private static WorkItemTrackingApi w;
 
-    @Test
-    public void shouldCreateAWorkItem() throws ConnectionException, AzDException {
-        w.createWorkItem("user story", WorkItemOperation.ADD, "Sample User story",
-                "Description for the user story", new String[]{"DevOps", "Java", "SDK"});
-    }
+	@Before
+	public void init() throws AzDException {
+		String dir = System.getProperty("user.dir");
+		File file = new File(dir + "/src/test/java/org/azd/_unitTest.json");
+		MockParameters m = MAPPER.mapJsonFromFile(file, MockParameters.class);
+		String organization = m.getO();
+		String token = m.getT();
+		String project = m.getP();
+		webApi = new AzDClientApi(organization, project, token);
+		w = webApi.getWorkItemTrackingApi();
+	}
 
-    @Test
-    public void shouldCreateAWorkItemWithAdditionalFields() throws ConnectionException, AzDException {
-        var additionalFields = new HashMap<String, Object>(){{
-            put("System.Tags", String.join(",", "DevOps", "Java", "SDK"));
-        }};
+	@Test
+	public void shouldGetWorkItem() throws ConnectionException, AzDException {
+		var expectedValue = "azure-devops-java-sdk";
+		var result = w.getWorkItem(2).getFields().getSystemTeamProject();
+		assertEquals(expectedValue, result);
+	}
 
-        w.createWorkItem("user story", "Sample User story",
-                "Description for the user story", additionalFields);
-    }
+	@Test
+	public void shouldGetWorkItemWithOptionalParameters() throws ConnectionException, AzDException {
+		var expectedValue = "azure-devops-java-sdk";
+		var result = w.getWorkItem(2, WorkItemExpand.ALL).getFields().getSystemTeamProject();
+		assertEquals(expectedValue, result);
+	}
 
-    @Test(expected = AzDException.class)
-    public void shouldDeleteAWorkItem() throws ConnectionException, AzDException {
-        w.deleteWorkItem(6);
-    }
+	@Test
+	public void shouldCreateAWorkItem() throws ConnectionException, AzDException {
+		w.createWorkItem("user story", WorkItemOperation.ADD, "Sample User story", "Description for the user story",
+				new String[] { "DevOps", "Java", "SDK" });
+	}
 
-    @Test
-    public void shouldGetWorkItems() throws ConnectionException, AzDException {
-        w.getWorkItems(new int[]{1,2,3});
-    }
+	@Test
+	public void shouldCreateAWorkItemWithAdditionalFields() throws ConnectionException, AzDException {
+		var additionalFields = new HashMap<String, Object>() {
 
-    @Test
-    public void shouldGetWorkItemRevisions() throws ConnectionException, AzDException {
-        var r = w.getWorkItemRevisions(3, WorkItemExpand.ALL)
-                .getWorkItems().stream().findFirst().get()
-                .getFields().getSystemAreaId();
-        assertEquals(12, r);
-    }
+			{
+				put("System.Tags", String.join(",", "DevOps", "Java", "SDK"));
+			}
+		};
 
-    @Test
-    public void shouldGetWorkItemRevision() throws ConnectionException, AzDException {
-        w.getWorkItemRevision(3, 1);
-    }
+		w.createWorkItem("user story", "Sample User story", "Description for the user story", additionalFields);
+	}
 
-    @Test
-    public void shouldQueryWorkItems() throws ConnectionException, AzDException {
-        var query = "Select * From WorkItems Where [System.WorkItemType] = 'User Story'";
-        var team = "azure-devops-java-sdk Team";
-        w.queryByWiql(team, query, 10, true).getWorkItems();
-    }
+	@Test(expected = AzDException.class)
+	public void shouldDeleteAWorkItem() throws ConnectionException, AzDException {
+		w.deleteWorkItem(6);
+	}
 
-    @Test
-    public void shouldQueryWorkItemsAndGetExactlyOneResult() throws ConnectionException, AzDException {
-        var query = "Select * From WorkItems Where [System.WorkItemType] = 'User Story'";
-        var team = "azure-devops-java-sdk Team";
-        var res = (long) w.queryByWiql(team, query, 1, true).getWorkItems().size();
-        assertEquals(1, res);
-    }
+	@Test
+	public void shouldGetWorkItems() throws ConnectionException, AzDException {
+		w.getWorkItems(new int[] { 1, 2, 3 });
+	}
 
-    @Test(expected = AzDException.class)
-    public void shouldRemoveWorkItemFromRecycleBin() throws ConnectionException, AzDException {
-        w.removeWorkItemFromRecycleBin(93);
-    }
+	@Test
+	public void shouldGetWorkItemRevisions() throws ConnectionException, AzDException {
+		var r = w.getWorkItemRevisions(3, WorkItemExpand.ALL).getWorkItems().stream().findFirst().get().getFields()
+				.getSystemAreaId();
+		assertEquals(12, r);
+	}
 
-    @Test
-    public void shouldGetWorkItemFromRecycleBin() throws ConnectionException, AzDException {
-        w.getWorkItemFromRecycleBin(74);
-    }
+	@Test
+	public void shouldGetWorkItemRevision() throws ConnectionException, AzDException {
+		w.getWorkItemRevision(3, 1);
+	}
 
-    @Test
-    public void shouldGetDeletedWorkItemFromRecycleBin() throws ConnectionException, AzDException {
-        w.getDeletedWorkItemsFromRecycleBin();
-    }
+	@Test
+	public void shouldQueryWorkItems() throws ConnectionException, AzDException {
+		var query = "Select * From WorkItems Where [System.WorkItemType] = 'User Story'";
+		var team = "azure-devops-java-sdk Team";
+		w.queryByWiql(team, query, 10, true).getWorkItems();
+	}
 
-    @Test(expected = AzDException.class)
-    public void shouldGetDeletedWorkItemsFromRecycleBin() throws ConnectionException, AzDException {
-        w.getDeletedWorkItemsFromRecycleBin(new int[]{71,72,73,74});
-    }
+	@Test
+	public void shouldQueryWorkItemsAndGetExactlyOneResult() throws ConnectionException, AzDException {
+		var query = "Select * From WorkItems Where [System.WorkItemType] = 'User Story'";
+		var team = "azure-devops-java-sdk Team";
+		var res = (long) w.queryByWiql(team, query, 1, true).getWorkItems().size();
+		assertEquals(1, res);
+	}
 
-    @Test(expected = AzDException.class)
-    public void shouldRestoreWorkItemFromRecycleBin() throws ConnectionException, AzDException {
-        w.restoreWorkItemFromRecycleBin(70);
-    }
+	@Test(expected = AzDException.class)
+	public void shouldRemoveWorkItemFromRecycleBin() throws ConnectionException, AzDException {
+		w.removeWorkItemFromRecycleBin(93);
+	}
 
-    @Test
-    public void shouldUpdateAWorkItem() throws ConnectionException, AzDException {
-        var fieldsToUpdate = new HashMap<String, Object>(){{
-            put("System.AssignedTo", "test@xmail.com");
-        }};
+	@Test
+	public void shouldGetWorkItemFromRecycleBin() throws ConnectionException, AzDException {
+		w.getWorkItemFromRecycleBin(74);
+	}
 
-        w.updateWorkItem(176, fieldsToUpdate);
-    }
+	@Test
+	public void shouldGetDeletedWorkItemFromRecycleBin() throws ConnectionException, AzDException {
+		w.getDeletedWorkItemsFromRecycleBin();
+	}
 
-    @Test
-    public void shouldGetWorkItemTypes() throws ConnectionException, AzDException {
-        w.getWorkItemTypes();
-    }
+	@Test(expected = AzDException.class)
+	public void shouldGetDeletedWorkItemsFromRecycleBin() throws ConnectionException, AzDException {
+		w.getDeletedWorkItemsFromRecycleBin(new int[] { 71, 72, 73, 74 });
+	}
 
-    @Test
-    public void shouldGetAWorkItemType() throws ConnectionException, AzDException {
-        w.getWorkItemType("Bug");
-    }
+	@Test(expected = AzDException.class)
+	public void shouldRestoreWorkItemFromRecycleBin() throws ConnectionException, AzDException {
+		w.restoreWorkItemFromRecycleBin(70);
+	}
+
+	@Test
+	public void shouldUpdateAWorkItem() throws ConnectionException, AzDException {
+		var fieldsToUpdate = new HashMap<String, Object>() {
+
+			{
+				put("System.AssignedTo", "test@xmail.com");
+			}
+		};
+
+		w.updateWorkItem(176, fieldsToUpdate);
+	}
+
+	@Test
+	public void shouldAddHyperlink() throws ConnectionException, AzDException {
+
+		Map<String, String> hyperlinksMap = new HashMap<>();
+		hyperlinksMap.put("https://docs.microsoft.com/en-us/rest/api/azure/devops",
+				"This is a hyperlink that points to the Azure DevOps REST documentation.");
+
+		w.addHyperLinks(1, hyperlinksMap);
+	}
+
+	@Test
+	public void shouldRemoveHyperlink() throws ConnectionException, AzDException {
+
+		List<String> hyperlinks = new ArrayList<>();
+		hyperlinks.add("https://docs.microsoft.com/en-us/rest/api/azure/devops");
+
+		try {
+			w.removeHyperLinks(1, hyperlinks);
+		} catch (AzDException e) {
+			// Test is also successful if hyperlink doesn't exist.
+			if (e.getMessage().toLowerCase().contains("the hyperlink doesn't exist")) {
+				return;
+			}
+
+			throw e;
+		}
+	}
+
+	@Test
+	public void shouldGetWorkItemTypes() throws ConnectionException, AzDException {
+		w.getWorkItemTypes();
+	}
+
+	@Test
+	public void shouldGetAWorkItemType() throws ConnectionException, AzDException {
+		w.getWorkItemType("Bug");
+	}
 }


### PR DESCRIPTION
First of all I want to thank the people that work on this project and are sharing it for free with everyone. It saves a lot of time for someone to do a Java API for Azure from scratch. For my purposes I found the API easy to understand and organized but lacking some functionality that I wanted so I added it.

My changes are:

1) Expanded the WorkItemTrackingDetails interface with two new
updateWorkItem methods because only the 'add' operation was supported.
Now all work item related operations
from azure are supported with the extra WorkItemOperation enumeration
parameter.

2) Expanded the same interface with two new methods for adding and
removing hyperlinks.