### PR TITLE
Refactor GraphEntity as parent of GraphUser and GraphGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**Breaking changes**
+- Added GraphEntity as parent of GraphUser and GraphGroup
+  - minor risk if extending from GraphUser or GraphGroup
+
 ## 3.0.5
 - Expanded the GitApi to get the branches of a repository or a specific branch from a repository based on the branch name.
 

--- a/azd/src/main/java/org/azd/graph/types/GraphEntity.java
+++ b/azd/src/main/java/org/azd/graph/types/GraphEntity.java
@@ -1,0 +1,164 @@
+package org.azd.graph.types;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/***
+ * Graph entity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GraphEntity {
+    /***
+     * This field contains zero or more interesting links about the graph subject.
+     * These links may be invoked to obtain additional relationships or more detailed information about this graph subject.
+     */
+    @JsonProperty("_links")
+    protected GraphReferenceLinks _links;
+    /***
+     * The descriptor is the primary way to reference the graph subject while the system is running.
+     * This field will uniquely identify the same graph subject across both Accounts and Organizations.
+     */
+    @JsonProperty("descriptor")
+    protected String descriptor;
+    /***
+     * This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider.
+     */
+    @JsonProperty("displayName")
+    protected String displayName;
+    /***
+     * This represents the name of the container of origin for a graph member.
+     */
+    @JsonProperty("domain")
+    protected String domain;
+    /***
+     * The email address of record for a given graph member. This may be different than the principal name.
+     */
+    @JsonProperty("mailAddress")
+    protected String mailAddress;
+    /***
+     * The type of source provider for the origin identifier (ex:AD, AAD, MSA)
+     */
+    @JsonProperty("origin")
+    protected String origin;
+    /***
+     * The unique identifier from the system of origin.
+     * Typically a sid, object id or Guid. Linking and unlinking operations
+     * can cause this value to change for a user because the user is not backed by a different provider
+     * and has a different unique id in the new provider.
+     */
+    @JsonProperty("originId")
+    protected String originId;
+    /***
+     * This is the PrincipalName of this graph member from the source provider.
+     * The source provider may change this field over time and it is not guaranteed
+     * to be immutable for the life of the graph member by VSTS.
+     */
+    @JsonProperty("principalName")
+    protected String principalName;
+    /***
+     * This field identifies the type of the graph subject (ex: Group, Scope, User).
+     */
+    @JsonProperty("subjectKind")
+    protected String subjectKind;
+    /***
+     * This url is the full route to the source resource of this graph subject.
+     */
+    @JsonProperty("url")
+    protected String url;
+
+    public GraphReferenceLinks get_links() {
+        return _links;
+    }
+
+    public void set_links(GraphReferenceLinks _links) {
+        this._links = _links;
+    }
+
+    public String getDescriptor() {
+        return descriptor;
+    }
+
+    public void setDescriptor(String descriptor) {
+        this.descriptor = descriptor;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+    public String getMailAddress() {
+        return mailAddress;
+    }
+
+    public void setMailAddress(String mailAddress) {
+        this.mailAddress = mailAddress;
+    }
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(String origin) {
+        this.origin = origin;
+    }
+
+    public String getOriginId() {
+        return originId;
+    }
+
+    public void setOriginId(String originId) {
+        this.originId = originId;
+    }
+
+    public String getPrincipalName() {
+        return principalName;
+    }
+
+    public void setPrincipalName(String principalName) {
+        this.principalName = principalName;
+    }
+
+    public String getSubjectKind() {
+        return subjectKind;
+    }
+
+    public void setSubjectKind(String subjectKind) {
+        this.subjectKind = subjectKind;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public String toString() {
+        return "GraphEntity{" +
+                "_links=" + _links +
+                ", descriptor='" + descriptor + '\'' +
+                ", displayName='" + displayName + '\'' +
+                ", domain='" + domain + '\'' +
+                ", mailAddress='" + mailAddress + '\'' +
+                ", origin='" + origin + '\'' +
+                ", originId='" + originId + '\'' +
+                ", principalName='" + principalName + '\'' +
+                ", subjectKind='" + subjectKind + '\'' +
+                ", url='" + url + '\'' +
+                '}';
+    }
+}

--- a/azd/src/main/java/org/azd/graph/types/GraphGroup.java
+++ b/azd/src/main/java/org/azd/graph/types/GraphGroup.java
@@ -7,83 +7,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Graph group entity
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class GraphGroup {
-    /***
-     * This field contains zero or more interesting links about the graph subject.
-     * These links may be invoked to obtain additional relationships or more detailed information about this graph subject.
-     */
-    @JsonProperty("_links")
-    private GroupReferenceLinks _links;
+public class GraphGroup extends GraphEntity {
     /***A short phrase to help human readers disambiguate groups with similar names
      *
      */
     @JsonProperty("description")
     private String description;
     /***
-     * The descriptor is the primary way to reference the graph subject while the system is running.
-     * This field will uniquely identify the same graph subject across both Accounts and Organizations.
-     */
-    @JsonProperty("descriptor")
-    private String descriptor;
-    /***
-     * This is the non-unique display name of the graph subject.
-     * To change this field, you must alter its value in the source provider.
-     */
-    @JsonProperty("displayName")
-    private String displayName;
-    /***
-     * This represents the name of the container of origin for a graph member.
-     */
-    @JsonProperty("domain")
-    private String domain;
-    /***
      * The legacy descriptor is here in case you need to access old version IMS using identity descriptor.
      */
     @JsonProperty("legacyDescriptor")
     private String legacyDescriptor;
-    /***
-     * The email address of record for a given graph member. This may be different than the principal name.
-     */
-    @JsonProperty("mailAddress")
-    private String mailAddress;
-    /***
-     * The type of source provider for the origin identifier (ex:AD, AAD, MSA)
-     */
-    @JsonProperty("origin")
-    private String origin;
-    /***
-     * The unique identifier from the system of origin.
-     * Typically a sid, object id or Guid. Linking and unlinking operations can cause this value
-     * to change for a user because the user is not backed by a different provider and has a
-     * different unique id in the new provider.
-     */
-    @JsonProperty("originId")
-    private String originId;
-    /***
-     * This is the PrincipalName of this graph member from the source provider.
-     * The source provider may change this field over time and it is not
-     * guaranteed to be immutable for the life of the graph member by VSTS.
-     */
-    @JsonProperty("principalName")
-    private String principalName;
-    /***
-     * This field identifies the type of the graph subject (ex: Group, Scope, User).
-     */
-    @JsonProperty("subjectKind")
-    private String subjectKind;
-    /***
-     * This url is the full route to the source resource of this graph subject.
-     */
-    @JsonProperty("url")
-    private String url;
-
-    public GroupReferenceLinks get_links() {
-        return _links;
-    }
-
-    public void set_links(GroupReferenceLinks _links) {
-        this._links = _links;
-    }
 
     public String getDescription() {
         return description;
@@ -91,30 +25,6 @@ public class GraphGroup {
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    public String getDescriptor() {
-        return descriptor;
-    }
-
-    public void setDescriptor(String descriptor) {
-        this.descriptor = descriptor;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String getDomain() {
-        return domain;
-    }
-
-    public void setDomain(String domain) {
-        this.domain = domain;
     }
 
     public String getLegacyDescriptor() {
@@ -125,63 +35,15 @@ public class GraphGroup {
         this.legacyDescriptor = legacyDescriptor;
     }
 
-    public String getMailAddress() {
-        return mailAddress;
-    }
-
-    public void setMailAddress(String mailAddress) {
-        this.mailAddress = mailAddress;
-    }
-
-    public String getOrigin() {
-        return origin;
-    }
-
-    public void setOrigin(String origin) {
-        this.origin = origin;
-    }
-
-    public String getOriginId() {
-        return originId;
-    }
-
-    public void setOriginId(String originId) {
-        this.originId = originId;
-    }
-
-    public String getPrincipalName() {
-        return principalName;
-    }
-
-    public void setPrincipalName(String principalName) {
-        this.principalName = principalName;
-    }
-
-    public String getSubjectKind() {
-        return subjectKind;
-    }
-
-    public void setSubjectKind(String subjectKind) {
-        this.subjectKind = subjectKind;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
     @Override
     public String toString() {
         return "GraphGroup{" +
-                "_links=" + _links +
-                ", description='" + description + '\'' +
+                "description='" + description + '\'' +
+                ", legacyDescriptor='" + legacyDescriptor + '\'' +
+                ", _links=" + _links +
                 ", descriptor='" + descriptor + '\'' +
                 ", displayName='" + displayName + '\'' +
                 ", domain='" + domain + '\'' +
-                ", legacyDescriptor='" + legacyDescriptor + '\'' +
                 ", mailAddress='" + mailAddress + '\'' +
                 ", origin='" + origin + '\'' +
                 ", originId='" + originId + '\'' +

--- a/azd/src/main/java/org/azd/graph/types/GraphReferenceLinks.java
+++ b/azd/src/main/java/org/azd/graph/types/GraphReferenceLinks.java
@@ -15,22 +15,22 @@ public class GraphReferenceLinks {
      * self reference url
      */
     @JsonProperty("self")
-    private Reference self;
+    protected Reference self;
     /***
      * Represents the ulr of membership API
      */
     @JsonProperty("memberships")
-    private Reference memberships;
+    protected Reference memberships;
     /***
      * Membership state url
      */
     @JsonProperty("membershipState")
-    private Reference membershipState;
+    protected Reference membershipState;
     /***
      * Storage key url
      */
     @JsonProperty("storageKey")
-    private Reference storageKey;
+    protected Reference storageKey;
 
     public Reference getSelf() {
         return self;

--- a/azd/src/main/java/org/azd/graph/types/GraphUser.java
+++ b/azd/src/main/java/org/azd/graph/types/GraphUser.java
@@ -7,19 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Graph user entity
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class GraphUser {
-    /***
-     * This field contains zero or more interesting links about the graph subject.
-     * These links may be invoked to obtain additional relationships or more detailed information about this graph subject.
-     */
-    @JsonProperty("_links")
-    private GraphReferenceLinks _links;
-    /***
-     * The descriptor is the primary way to reference the graph subject while the system is running.
-     * This field will uniquely identify the same graph subject across both Accounts and Organizations.
-     */
-    @JsonProperty("descriptor")
-    private String descriptor;
+public class GraphUser extends GraphEntity {
     /***
      * The short, generally unique name for the user in the backing directory.
      * For AAD users, this corresponds to the mail nickname, which is often but not
@@ -28,16 +16,6 @@ public class GraphUser {
      */
     @JsonProperty("directoryAlias")
     private String directoryAlias;
-    /***
-     * This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider.
-     */
-    @JsonProperty("displayName")
-    private String displayName;
-    /***
-     * This represents the name of the container of origin for a graph member.
-     */
-    @JsonProperty("domain")
-    private String domain;
     /***
      * When true, the group has been deleted in the identity provider
      */
@@ -49,61 +27,10 @@ public class GraphUser {
     @JsonProperty("legacyDescriptor")
     private String legacyDescriptor;
     /***
-     * The email address of record for a given graph member. This may be different than the principal name.
-     */
-    @JsonProperty("mailAddress")
-    private String mailAddress;
-    /***
      * The meta type of the user in the origin, such as "member", "guest", etc. See UserMetaType for the set of possible values.
      */
     @JsonProperty("metaType")
     private String metaType;
-    /***
-     * The type of source provider for the origin identifier (ex:AD, AAD, MSA)
-     */
-    @JsonProperty("origin")
-    private String origin;
-    /***
-     * The unique identifier from the system of origin.
-     * Typically a sid, object id or Guid. Linking and unlinking operations
-     * can cause this value to change for a user because the user is not backed by a different provider
-     * and has a different unique id in the new provider.
-     */
-    @JsonProperty("originId")
-    private String originId;
-    /***
-     * This is the PrincipalName of this graph member from the source provider.
-     * The source provider may change this field over time and it is not guaranteed
-     * to be immutable for the life of the graph member by VSTS.
-     */
-    @JsonProperty("principalName")
-    private String principalName;
-    /***
-     * This field identifies the type of the graph subject (ex: Group, Scope, User).
-     */
-    @JsonProperty("subjectKind")
-    private String subjectKind;
-    /***
-     * This url is the full route to the source resource of this graph subject.
-     */
-    @JsonProperty("url")
-    private String url;
-
-    public GraphReferenceLinks get_links() {
-        return _links;
-    }
-
-    public void set_links(GraphReferenceLinks _links) {
-        this._links = _links;
-    }
-
-    public String getDescriptor() {
-        return descriptor;
-    }
-
-    public void setDescriptor(String descriptor) {
-        this.descriptor = descriptor;
-    }
 
     public String getDirectoryAlias() {
         return directoryAlias;
@@ -111,22 +38,6 @@ public class GraphUser {
 
     public void setDirectoryAlias(String directoryAlias) {
         this.directoryAlias = directoryAlias;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String getDomain() {
-        return domain;
-    }
-
-    public void setDomain(String domain) {
-        this.domain = domain;
     }
 
     public boolean isDeletedInOrigin() {
@@ -145,14 +56,6 @@ public class GraphUser {
         this.legacyDescriptor = legacyDescriptor;
     }
 
-    public String getMailAddress() {
-        return mailAddress;
-    }
-
-    public void setMailAddress(String mailAddress) {
-        this.mailAddress = mailAddress;
-    }
-
     public String getMetaType() {
         return metaType;
     }
@@ -161,58 +64,18 @@ public class GraphUser {
         this.metaType = metaType;
     }
 
-    public String getOrigin() {
-        return origin;
-    }
-
-    public void setOrigin(String origin) {
-        this.origin = origin;
-    }
-
-    public String getOriginId() {
-        return originId;
-    }
-
-    public void setOriginId(String originId) {
-        this.originId = originId;
-    }
-
-    public String getPrincipalName() {
-        return principalName;
-    }
-
-    public void setPrincipalName(String principalName) {
-        this.principalName = principalName;
-    }
-
-    public String getSubjectKind() {
-        return subjectKind;
-    }
-
-    public void setSubjectKind(String subjectKind) {
-        this.subjectKind = subjectKind;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
     @Override
     public String toString() {
         return "GraphUser{" +
-                "_links=" + _links +
-                ", descriptor='" + descriptor + '\'' +
-                ", directoryAlias='" + directoryAlias + '\'' +
-                ", displayName='" + displayName + '\'' +
-                ", domain='" + domain + '\'' +
+                "directoryAlias='" + directoryAlias + '\'' +
                 ", isDeletedInOrigin=" + isDeletedInOrigin +
                 ", legacyDescriptor='" + legacyDescriptor + '\'' +
-                ", mailAddress='" + mailAddress + '\'' +
                 ", metaType='" + metaType + '\'' +
+                ", _links=" + _links +
+                ", descriptor='" + descriptor + '\'' +
+                ", displayName='" + displayName + '\'' +
+                ", domain='" + domain + '\'' +
+                ", mailAddress='" + mailAddress + '\'' +
                 ", origin='" + origin + '\'' +
                 ", originId='" + originId + '\'' +
                 ", principalName='" + principalName + '\'' +

--- a/azd/src/main/java/org/azd/graph/types/GroupReferenceLinks.java
+++ b/azd/src/main/java/org/azd/graph/types/GroupReferenceLinks.java
@@ -7,61 +7,10 @@ import org.azd.common.types.Reference;
 /***
  * This field contains zero or more interesting links about the graph subject.
  * These links may be invoked to obtain additional relationships or more detailed information about this graph subject.
+ * @deprecated This is identical to {@link GraphReferenceLinks} and all references should be updated accordingly
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class GroupReferenceLinks {
-    /***
-     * Self reference url
-     */
-    @JsonProperty("self")
-    private Reference self;
-    /***
-     * Represents the ulr of membership API
-     */
-    @JsonProperty("memberships")
-    private Reference memberships;
-    /***
-     * Membership state url
-     */
-    @JsonProperty("membershipState")
-    private Reference membershipState;
-    /***
-     * Storage key url
-     */
-    @JsonProperty("storageKey")
-    private Reference storageKey;
-
-    public Reference getSelf() {
-        return self;
-    }
-
-    public void setSelf(Reference self) {
-        this.self = self;
-    }
-
-    public Reference getMemberships() {
-        return memberships;
-    }
-
-    public void setMemberships(Reference memberships) {
-        this.memberships = memberships;
-    }
-
-    public Reference getMembershipState() {
-        return membershipState;
-    }
-
-    public void setMembershipState(Reference membershipState) {
-        this.membershipState = membershipState;
-    }
-
-    public Reference getStorageKey() {
-        return storageKey;
-    }
-
-    public void setStorageKey(Reference storageKey) {
-        this.storageKey = storageKey;
-    }
+public class GroupReferenceLinks extends GraphReferenceLinks {
 
     @Override
     public String toString() {

--- a/azd/src/main/java/org/azd/graph/types/SubjectLookup.java
+++ b/azd/src/main/java/org/azd/graph/types/SubjectLookup.java
@@ -11,93 +11,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SubjectLookup {
-    /***
-     * This field contains zero or more interesting links about the graph subject.
-     * These links may be invoked to obtain additional relationships or more detailed information about this graph subject.
-     */
-    @JsonProperty("_links")
-    private GraphReferenceLinks _links;
-    /***
-     * The descriptor is the primary way to reference the graph subject while the system is running.
-     * This field will uniquely identify the same graph subject across both Accounts and Organizations.
-     */
-    @JsonProperty("descriptor")
-    private String descriptor;
-    /***
-     * Identifies whether this is a 'group' or a 'user'
-     */
-    @JsonProperty("subjectKind")
-    private String subjectKind;
+public class SubjectLookup extends GraphEntity {
     /***
      * verbose description of the subject
      */
     @JsonProperty("description")
     private String description;
-    /***
-     * This represents the name of the container of origin for a graph member.
-     */
-    @JsonProperty("domain")
-    private String domain;
-    /***
-     * This is the PrincipalName of this graph member from the source provider.
-     * The source provider may change this field over time and it is not guaranteed
-     * to be immutable for the life of the graph member by VSTS.
-     */
-    @JsonProperty("principalName")
-    private String principalName;
-    /***
-     * The email address of record for a given graph member. This may be different than the principal name.
-     */
-    @JsonProperty("mailAddress")
-    private String mailAddress;
-    /***
-     * The type of source provider for the origin identifier (ex:AD, AAD, MSA)
-     */
-    @JsonProperty("origin")
-    private String origin;
-    /***
-     * The unique identifier from the system of origin.
-     * Typically a sid, object id or Guid. Linking and unlinking operations
-     * can cause this value to change for a user because the user is not backed by a different provider
-     * and has a different unique id in the new provider.
-     */
-    @JsonProperty("originId")
-    private String originId;
-    /***
-     * This is the non-unique display name of the graph subject.
-     */
-    @JsonProperty("displayName")
-    private String displayName;
-    /***
-     * This url is the full route to the source resource of this graph subject.
-     */
-    @JsonProperty("url")
-    private String url;
-
-    public GraphReferenceLinks get_links() {
-        return _links;
-    }
-
-    public void set_links(GraphReferenceLinks _links) {
-        this._links = _links;
-    }
-
-    public String getDescriptor() {
-        return descriptor;
-    }
-
-    public void setDescriptor(String descriptor) {
-        this.descriptor = descriptor;
-    }
-
-    public String getSubjectKind() {
-        return subjectKind;
-    }
-
-    public void setSubjectKind(String subjectKind) {
-        this.subjectKind = subjectKind;
-    }
 
     public String getDescription() {
         return description;
@@ -107,75 +26,19 @@ public class SubjectLookup {
         this.description = description;
     }
 
-    public String getDomain() {
-        return domain;
-    }
-
-    public void setDomain(String domain) {
-        this.domain = domain;
-    }
-
-    public String getPrincipalName() {
-        return principalName;
-    }
-
-    public void setPrincipalName(String principalName) {
-        this.principalName = principalName;
-    }
-
-    public String getMailAddress() {
-        return mailAddress;
-    }
-
-    public void setMailAddress(String mailAddress) {
-        this.mailAddress = mailAddress;
-    }
-
-    public String getOrigin() {
-        return origin;
-    }
-
-    public void setOrigin(String origin) {
-        this.origin = origin;
-    }
-
-    public String getOriginId() {
-        return originId;
-    }
-
-    public void setOriginId(String originId) {
-        this.originId = originId;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
     @Override
     public String toString() {
         return "SubjectLookup{" +
-                "_links=" + _links +
+                "description='" + description + '\'' +
+                ", _links=" + _links +
                 ", descriptor='" + descriptor + '\'' +
-                ", subjectKind='" + subjectKind + '\'' +
-                ", description='" + description + '\'' +
+                ", displayName='" + displayName + '\'' +
                 ", domain='" + domain + '\'' +
-                ", principalName='" + principalName + '\'' +
                 ", mailAddress='" + mailAddress + '\'' +
                 ", origin='" + origin + '\'' +
                 ", originId='" + originId + '\'' +
-                ", displayName='" + displayName + '\'' +
+                ", principalName='" + principalName + '\'' +
+                ", subjectKind='" + subjectKind + '\'' +
                 ", url='" + url + '\'' +
                 '}';
     }


### PR DESCRIPTION
## Description

Refactor: 
- Create GraphEntity parent class to encapsulate common attributes and reduce redundant calls to lookups.
  - example: 
  ```
  void addMemberToGroup(GraphEntity member, GraphGroup group) throws AzureDevopsApiException {
        GraphMembership graphMembership = graphApi.addMembership(member.getDescriptor(), group.getDescriptor());
  }
  ```
- consolidate GraphReferenceLinks/GroupReferenceLinks classes
No changes to unit tests or help doc (should behave the same).

## PR Checklist

- [x] Added help
- [x] Added unit test/s
- [x] Updated Change log