### PR TITLE
fix downloadPackage exception handling

### DIFF
--- a/azd/src/main/java/org/azd/interfaces/MavenDetails.java
+++ b/azd/src/main/java/org/azd/interfaces/MavenDetails.java
@@ -7,7 +7,6 @@ import org.azd.maven.types.MavenPackageVersionDeletionState;
 import org.azd.maven.types.Package;
 import org.azd.maven.types.UpstreamingBehavior;
 
-import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;

--- a/azd/src/main/java/org/azd/maven/MavenApi.java
+++ b/azd/src/main/java/org/azd/maven/MavenApi.java
@@ -5,6 +5,7 @@ import org.azd.connection.Connection;
 import org.azd.enums.*;
 import org.azd.exceptions.AzDException;
 import org.azd.helpers.JsonMapper;
+import org.azd.helpers.StreamHelper;
 import org.azd.interfaces.MavenDetails;
 import org.azd.maven.types.MavenPackageVersionDeletionState;
 import org.azd.maven.types.Package;
@@ -156,10 +157,18 @@ public class MavenApi extends AzDAsyncApi<MavenApi> implements MavenDetails {
                 .thenApplyAsync(URI::toString)
                 .join();
 
+        int statusCode = send(callbackUri, RequestMethod.GET, null, null, null,
+                null, null, null, null, null, null, null, true)
+                .thenApplyAsync(HttpResponse::statusCode)
+                .join();
+
         var res = send(callbackUri, RequestMethod.GET, null, null, null,
                 null, null, null, null, null, null, null, true)
                 .thenApplyAsync(HttpResponse::body)
-                .join();
+                .join();         
+                
+        if(statusCode != 200)
+            MAPPER.mapJsonResponse(StreamHelper.convertToString(res), Map.class);
 
         return res;
     }


### PR DESCRIPTION
# Azure DevOps java sdk pull request template guide

Thank you for your interest in contributing to this project.

## Description

downloadpackage not handling http exception(4xx)  
If an exception occurs, a message is written to a file.
![image](https://user-images.githubusercontent.com/25363091/188630737-9027d8b9-0394-4cfe-a61f-40eb2cf1a0ab.png)

I modified it to receive HttpBody and parsing json, if the statuscode is not 200.(Inducing AzdException to occur)

``` java
// MavenApi.java
public InputStream downloadPackage(String feedId, String groupId, String artifactId, String version, String fileName) throws AzDException {
...
if(statusCode != 200)
  MAPPER.mapJsonResponse(StreamHelper.convertToString(res), Map.class); // will AzDException fire
}
```

## PR Checklist

- [ ] Added help
- [ ] Added unit test/s
- [ ] Updated Change log