### PR TITLE
Fix issue 52, change size field from Integer to Long

### DIFF
--- a/azd/src/main/java/org/azd/git/types/GitRepository.java
+++ b/azd/src/main/java/org/azd/git/types/GitRepository.java
@@ -53,7 +53,7 @@ public class GitRepository extends BaseAbstractMethod {
  	* Compressed size (bytes) of the repository. 
 	**/
 	@JsonProperty("size")
-	private Integer size;
+	private Long size;
 
 	@JsonProperty("sshUrl")
 	private String sshUrl;
@@ -103,9 +103,9 @@ public class GitRepository extends BaseAbstractMethod {
 
 	public void setRemoteUrl(String remoteUrl) { this.remoteUrl = remoteUrl; }
 
-	public Integer getSize() { return size; }
+	public Long getSize() { return size; }
 
-	public void setSize(Integer size) { this.size = size; }
+	public void setSize(Long size) { this.size = size; }
 
 	public String getSshUrl() { return sshUrl; }
 


### PR DESCRIPTION
Fix issue 52, change size field from Integer to Long. With this fix now is possible to clone repositories with size greater than 2147483647 bytes.

# Azure DevOps java sdk pull request template guide

Thank you for your interest in contributing to this project.

## Description

Describe your PR in few words.

## PR Checklist

- [ ] Added help
- [ ] Added unit test/s
- [ ] Updated Change log